### PR TITLE
[feat/front]통계 시각화 페이지 Chart.js로 구성

### DIFF
--- a/frontend/src/components/ChartBox.jsx
+++ b/frontend/src/components/ChartBox.jsx
@@ -1,0 +1,36 @@
+// src/components/ChartBox.jsx
+import React from 'react';
+import { Bar } from 'react-chartjs-2';
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+function ChartBox({ title, labels, data }) {
+  return (
+    <div style={{ marginBottom: '40px' }}>
+      <h3>{title}</h3>
+      <Bar
+        data={{
+          labels: labels,
+          datasets: [
+            {
+              label: title,
+              data: data,
+              backgroundColor: 'rgba(75, 192, 192, 0.6)',
+              borderRadius: 5
+            }
+          ]
+        }}
+        options={{
+          responsive: true,
+          plugins: {
+            legend: { position: 'top' },
+            title: { display: false },
+          },
+        }}
+      />
+    </div>
+  );
+}
+
+export default ChartBox;

--- a/frontend/src/pages/StatsPage.jsx
+++ b/frontend/src/pages/StatsPage.jsx
@@ -1,0 +1,26 @@
+// src/pages/StatsPage.jsx
+import React from 'react';
+import ChartBox from '../components/ChartBox';
+
+function StatsPage() {
+  // 🎯 mock 데이터
+  const yearStats = {
+    labels: ['2021', '2022', '2023'],
+    data: [2, 5, 3]
+  };
+
+  const courtStats = {
+    labels: ['서울고등법원', '대법원', '서울중앙지방법원'],
+    data: [4, 2, 5]
+  };
+
+  return (
+    <div style={{ maxWidth: '800px', margin: '0 auto', padding: '40px' }}>
+      <h2 style={{ textAlign: 'center' }}>판례 통계 시각화</h2>
+      <ChartBox title="연도별 사건 수" labels={yearStats.labels} data={yearStats.data} />
+      <ChartBox title="법원별 사건 분포" labels={courtStats.labels} data={courtStats.data} />
+    </div>
+  );
+}
+
+export default StatsPage;


### PR DESCRIPTION
## 📊 작업 내용
- StatsPage.jsx 생성
- ChartBox.jsx 컴포넌트 생성
- Chart.js 및 react-chartjs-2 설치 및 적용
- 연도별 사건 수, 법원별 사건 분포 mock 데이터 시각화

## 🗂 변경된 파일
- src/pages/StatsPage.jsx
- src/components/ChartBox.jsx
- package.json (Chart.js 설치 시 자동 반영)

## ✅ 확인 방법
- `/stats` 라우트 접속 시 차트 시각화 확인 가능
- mock 데이터 기반 시각화 → API 연동은 추후 적용 예정

## ⚠️ 기타
- 차트 색상 및 세부 스타일은 추후 사용자 피드백 기반 개선 예정
